### PR TITLE
Update snap base and add snap.yaml, a github action workflow

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -7,6 +7,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: snapcore/action-build@v1
         id: build
+        with:
+          snapcraft-channel: beta
       - uses: actions/upload-artifact@v7
         with:
           name: snap

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -1,5 +1,7 @@
 on:
   push:
+    branches:
+      - main
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -15,7 +15,7 @@ jobs:
           path: ${{ steps.build.outputs.snap }}
       - uses: snapcore/action-publish@v1
         env:
-          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
         with:
           snap: ${{ steps.build.outputs.snap }}
           release: edge

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -11,3 +11,9 @@ jobs:
         with:
           name: snap
           path: ${{ steps.build.outputs.snap }}
+      - uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+        with:
+          snap: ${{ steps.build.outputs.snap }}
+          release: edge

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -6,18 +6,18 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - uses: snapcore/action-build@v1
+      - uses: snapcore/action-build@3bdaa03e1ba6bf59a65f84a751d943d549a54e79 # v1
         id: build
         with:
           snapcraft-channel: beta
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: snap
           path: ${{ steps.build.outputs.snap }}
-      - uses: snapcore/action-publish@v1
+      - uses: snapcore/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40 # v1
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
         with:

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: snapcore/action-build@v1
         id: build
         with:

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -1,0 +1,8 @@
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: snapcore/action-build@v1

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -6,3 +6,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: snapcore/action-build@v1
+        id: build
+      - uses: actions/upload-artifact@v7
+        with:
+          name: snap
+          path: ${{ steps.build.outputs.snap }}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,7 +8,7 @@ description: |
 
 grade: stable
 confinement: classic
-base: core18
+base: core24
 type: app
 
 apps:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,7 +8,7 @@ description: |
 
 grade: stable
 confinement: classic
-base: core24
+base: core26
 type: app
 
 apps:


### PR DESCRIPTION
This updates the base to core24 because 18 doesn't work with the snapcraft that the action uses by default. This also adds a github action workflow to build and upload-artifact and publish the snap to the snapcraft store.

I didn't test the publish.
It needs a SNAPCRAFT_STORE_CREDENTIALS set in  
https://github.com/jbangdev/jbang-snap/settings/secrets/actions  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated CI workflow to build, archive, and publish the Snap package on pushes to main.
  * Upgraded the Snap package base platform to a newer major release for improved compatibility and longer-term support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbangdev/jbang-snap/pull/2?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->