### PR TITLE
ci: follow snapcraft channel stable instead of beta

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -11,8 +11,6 @@ jobs:
           persist-credentials: false
       - uses: snapcore/action-build@3bdaa03e1ba6bf59a65f84a751d943d549a54e79 # v1
         id: build
-        with:
-          snapcraft-channel: beta
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: snap


### PR DESCRIPTION
`snap info snapcraft` now says stable is on version 9 so following the beta channel is no longer needed.

Also I think something is wrong with the snap store credentials.
https://github.com/jbangdev/jbang-snap/actions/runs/27884859321/job/82518477227
```
Exported credentials are no longer valid for the Snap Store.
Recommended resolution: Run export-login and update SNAPCRAFT_STORE_CREDENTIALS.
For more information, check out: https://documentation.ubuntu.com/snapcraft/stable/how-to/publishing/authenticate
```

Edit: here is it building but not publishing on my account:
https://github.com/sixcorners/jbang-snap/actions/runs/28484951567/job/84429254277